### PR TITLE
#1 partial typescript compilation

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,13 +4,11 @@
   "private": true,
   "scripts": {
     "build": "tsc",
-    "start": "nodemon -e ts --exec \"(npm run lint -- --force && tsc && node build/server.js) || true\"",
+    "start": "npm run build && npm-run-all --parallel build:watch lint:watch serve:watch",
     "test": "jest",
     "lint": "tslint -t stylish 'src/**/*.ts'",
-    "dev": "npm run build:watch | npm run start:watch",
-    "dev2": "npm-run-all --parallel build:watch lint:watch start:watch",
     "build:watch": "tsc --watch",
-    "start:watch": "nodemon --ext js --delay 250ms build/server.js",
+    "serve:watch": "nodemon --ext js --delay 250ms build/server.js",
     "lint:watch": "chokidar \"**/*.ts\" -c \"npm run lint\""
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -4,12 +4,12 @@
   "private": true,
   "scripts": {
     "build": "tsc",
-    "start": "npm run build && npm-run-all --parallel build:watch lint:watch serve:watch",
+    "start": "npm run lint && npm run build && npm-run-all --parallel build:watch lint:watch serve:watch",
     "test": "jest",
     "lint": "tslint -t stylish 'src/**/*.ts'",
     "build:watch": "tsc --watch",
     "serve:watch": "nodemon --ext js --delay 250ms build/server.js",
-    "lint:watch": "chokidar \"**/*.ts\" -c \"npm run lint\""
+    "lint:watch": "chokidar \"**/*.ts\" -c \"tslint -t stylish '{path}'\""
   },
   "engines": {
     "node": ">= 7.6.0"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "tslint -t stylish 'src/**/*.ts'",
     "dev": "npm run build:watch | npm run start:watch",
     "build:watch": "tsc --watch",
-    "start:watch": "nodemon --ext js --delay 250ms build/server.js"
+    "start:watch": "nodemon --ext js --delay 250ms build/server.js",
+    "lint:watch": "chokidar \"**/*.ts\" -c \"npm run lint\""
   },
   "engines": {
     "node": ">= 7.6.0"
@@ -35,6 +36,7 @@
     "@types/koa": "2.0.39",
     "@types/koa-router": "7.0.22",
     "@types/request-promise": "4.1.33",
+    "chokidar-cli": "1.2.0",
     "jest": "20.0.0",
     "nodemon": "1.11.0",
     "ts-jest": "20.0.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "tslint -t stylish 'src/**/*.ts'",
     "dev": "npm run build:watch | npm run start:watch",
     "build:watch": "tsc --watch",
-    "start:watch": "nodemon -e js build/server.js"
+    "start:watch": "nodemon --ext js --delay 250ms build/server.js"
   },
   "engines": {
     "node": ">= 7.6.0"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test": "jest",
     "lint": "tslint -t stylish 'src/**/*.ts'",
     "dev": "npm run build:watch | npm run start:watch",
+    "dev2": "npm-run-all --parallel build:watch lint:watch start:watch",
     "build:watch": "tsc --watch",
     "start:watch": "nodemon --ext js --delay 250ms build/server.js",
     "lint:watch": "chokidar \"**/*.ts\" -c \"npm run lint\""
@@ -39,6 +40,7 @@
     "chokidar-cli": "1.2.0",
     "jest": "20.0.0",
     "nodemon": "1.11.0",
+    "npm-run-all": "4.0.2",
     "ts-jest": "20.0.1",
     "tslint": "5.2.0",
     "typescript": "2.3.2"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "@types/request-promise": "4.1.33",
     "chokidar-cli": "1.2.0",
     "jest": "20.0.0",
-    "nodemon": "1.11.0",
     "ts-jest": "20.0.1",
     "tsc-watch": "^1.0.5",
     "tslint": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "private": true,
   "scripts": {
     "build": "tsc",
-    "start": "npm-run-all lint --parallel lint:watch build:watch",
+    "start": "npm run lint && npm run lint:watch & npm run build:watch",
     "test": "jest",
     "lint": "tslint -t stylish 'src/**/*.ts'",
-    "build:watch": "tsc-watch --onSuccess 'node build/server.js'",
+    "build:watch": "tsc-watch --onSuccess \"node build/server.js\"",
     "lint:watch": "chokidar \"src/**/*.ts\" -c \"tslint -t stylish --force '{path}'\""
   },
   "engines": {
@@ -37,7 +37,6 @@
     "chokidar-cli": "1.2.0",
     "jest": "20.0.0",
     "nodemon": "1.11.0",
-    "npm-run-all": "4.0.2",
     "ts-jest": "20.0.1",
     "tsc-watch": "^1.0.5",
     "tslint": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "jest": "20.0.0",
     "npm-run-all": "4.0.2",
     "ts-jest": "20.0.1",
-    "tsc-watch": "^1.0.5",
+    "tsc-watch": "1.0.5",
     "tslint": "5.2.0",
     "typescript": "2.3.2"
   },

--- a/package.json
+++ b/package.json
@@ -4,11 +4,10 @@
   "private": true,
   "scripts": {
     "build": "tsc",
-    "start": "npm-run-all lint build --parallel build:watch lint:watch serve:watch",
+    "start": "npm-run-all lint --parallel lint:watch build:watch",
     "test": "jest",
     "lint": "tslint -t stylish 'src/**/*.ts'",
-    "build:watch": "tsc --watch",
-    "serve:watch": "nodemon --ext js --delay 250ms build/server.js",
+    "build:watch": "tsc-watch --onSuccess 'node build/server.js'",
     "lint:watch": "chokidar \"src/**/*.ts\" -c \"tslint -t stylish --force '{path}'\""
   },
   "engines": {
@@ -40,6 +39,7 @@
     "nodemon": "1.11.0",
     "npm-run-all": "4.0.2",
     "ts-jest": "20.0.1",
+    "tsc-watch": "^1.0.5",
     "tslint": "5.2.0",
     "typescript": "2.3.2"
   },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "tslint -t stylish 'src/**/*.ts'",
     "build:watch": "tsc --watch",
     "serve:watch": "nodemon --ext js --delay 250ms build/server.js",
-    "lint:watch": "chokidar \"**/*.ts\" -c \"tslint -t stylish '{path}'\""
+    "lint:watch": "chokidar \"src/**/*.ts\" -c \"tslint -t stylish --force '{path}'\""
   },
   "engines": {
     "node": ">= 7.6.0"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build": "tsc",
-    "start": "npm run lint && npm run build && npm-run-all --parallel build:watch lint:watch serve:watch",
+    "start": "npm-run-all lint build --parallel build:watch lint:watch serve:watch",
     "test": "jest",
     "lint": "tslint -t stylish 'src/**/*.ts'",
     "build:watch": "tsc --watch",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build": "tsc",
-    "start": "npm run lint && npm run lint:watch & npm run build:watch",
+    "start": "npm run lint && run-p lint:watch build:watch",
     "test": "jest",
     "lint": "tslint -t stylish 'src/**/*.ts'",
     "build:watch": "tsc-watch --onSuccess \"node build/server.js\"",
@@ -36,6 +36,7 @@
     "@types/request-promise": "4.1.33",
     "chokidar-cli": "1.2.0",
     "jest": "20.0.0",
+    "npm-run-all": "4.0.2",
     "ts-jest": "20.0.1",
     "tsc-watch": "^1.0.5",
     "tslint": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
     "build": "tsc",
     "start": "nodemon -e ts --exec \"(npm run lint -- --force && tsc && node build/server.js) || true\"",
     "test": "jest",
-    "lint": "tslint -t stylish 'src/**/*.ts'"
+    "lint": "tslint -t stylish 'src/**/*.ts'",
+    "dev": "npm run build:watch | npm run start:watch",
+    "build:watch": "tsc --watch",
+    "start:watch": "nodemon -e js build/server.js"
   },
   "engines": {
     "node": ">= 7.6.0"


### PR DESCRIPTION
- added two dev dependencies (chokidar for watching file changes for tslint, and npm-run-all to run tasks in parallel)
- npm start task replaced with the new one, that builds and runs linter for the first time, and then runs ts compilator, linter and nodemon in parallel.
-----------------
tsc doesn't support any kind of extended action on file change event, that is why I couldn't trigger those actions from tsc. tslint doesn't support watch mode at all. So I added a npm-run-all to run all those tasks in parallel. It seems not very stable and elegant solution, but it works for now. The compilation time on ordinary typescript file change became almost 3 times faster (on my machine). But it is not very stable inside cmder (but pretty stable in cmd.exe). Could you have a look please when have time for that?