### PR TITLE
Issue #7 configure ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,3 @@ cache:
 script:
   - npm run test:all
   - npm run build
-# killme please
-branches:
-  only:
-    issue-7-configure-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: node_js
+env:
+  CI=true
+node_js:
+  - 7.6.0
+  - 7.6
+  - 7
+cache:
+  directories:
+    - node_modules
+script:
+  - npm run test:all
+  - npm run build
+# killme please
+branches:
+  only:
+    issue-7-configure-ci

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
- # koa-graphql-ts-template
+[![Build Status](https://travis-ci.org/ctco-dev/koa-graphql-ts-template.svg?branch=master)](https://travis-ci.org/ctco-dev/koa-graphql-ts-template)
+
+# koa-graphql-ts-template
  
 Koa, GraphQL and TypeScript template project with batteries included.
 


### PR DESCRIPTION
Resolves #7 
Probably you'll want to remove env section, as env variables may be specified in travis UI.
Node versions selected as a minimal allowed by restrictions (7.6.0), the last patch (7.6.x) and the last minor (7).
Badge added to readme.
Please, notice, build task is run even test task fails (may be useful for diagnostics). If the opposite is needed please inform.