### PR TITLE
Removed tslint --force parameter

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,13 +3,13 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "build": "tsc",
+    "build": "npm run lint && tsc",
     "start": "npm run lint && run-p lint:watch build:watch",
     "test": "npm run test:all",
     "test:integration": "jest --config jest/integration.config.js",
     "test:unit": "jest --config jest/unit.config.js",
     "test:all": "jest",
-    "lint": "tslint -t stylish 'src/**/*.ts' --force",
+    "lint": "tslint -t stylish 'src/**/*.ts'",
     "build:watch": "tsc-watch --onSuccess \"node build/server.js\"",
     "lint:watch": "chokidar \"src/**/*.ts\" -c \"tslint -t stylish --force '{path}'\""
   },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build": "npm run lint && tsc",
-    "start": "npm run lint && run-p lint:watch build:watch",
+    "start": "npm run lint -- --force && run-p lint:watch build:watch",
     "test": "npm run test:all",
     "test:integration": "jest --config jest/integration.config.js",
     "test:unit": "jest --config jest/unit.config.js",


### PR DESCRIPTION
### Description
Removed `--force` parameter from npm `lint` task, which caused linter to exit with status code 0 even if linter returned errors, causing build to proceed even when linting errors were detected.

Added `npm run lint` to npm `build` task to run linter before building the app.

### Relevant issue
Resolves #24